### PR TITLE
KBASE-5352: accept workspace id to save reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: Python
+
+sudo: required
+
+services:
+  - docker
+
+branches:
+  only:
+    - master
+
+before_install:
+    - docker version
+    - python --version
+
+install:
+    - git clone https://github.com/kbase/jars
+    - git clone https://github.com/kbase/kb_sdk
+    - cd kb_sdk
+    - make
+    - make sdkbase
+    - docker images
+    - export PATH=$(pwd)/bin:$PATH
+    - cd ../
+
+script:
+  - kb-sdk validate

--- a/KBaseReport.spec
+++ b/KBaseReport.spec
@@ -58,7 +58,7 @@ module KBaseReport {
     } Report;
 
     /*
-        Provide the report information.  The structure is:
+        Provide the report information. Either workspace name or workspace id is required  The structure is:
             params = {
                 report: {
                     text_message: '',
@@ -69,6 +69,7 @@ module KBaseReport {
                     }]
                 },
                 workspace_name: 'ws'
+                workspace_id: id
             }
     */
 
@@ -76,6 +77,7 @@ module KBaseReport {
     typedef structure {
         Report report;
         string workspace_name;
+        int workspace_id;
     } CreateParams;
 
     /*
@@ -120,7 +122,9 @@ module KBaseReport {
         string report_object_name - name to use for the report object (job ID is used if left unspecified)
         html_window_height - height of the html window in the narrative output widget
         summary_window_height - height of summary window in the narrative output widget
+        One of the following:
         string workspace_name - name of workspace where object should be saved
+        int workspace_id - id of workspace where object should be saved
     */
     typedef structure {
         string message;
@@ -134,6 +138,7 @@ module KBaseReport {
         float html_window_height;
         float summary_window_height;
         string workspace_name;
+        int workspace_id;
     } CreateExtendedReportParams;
     /*
         A more complex function to create a report that enables the user to specify files and html view that the report should link to

--- a/lib/KBaseReport/KBaseReportClient.pm
+++ b/lib/KBaseReport/KBaseReportClient.pm
@@ -124,6 +124,7 @@ $info is a KBaseReport.ReportInfo
 CreateParams is a reference to a hash where the following keys are defined:
 	report has a value which is a KBaseReport.Report
 	workspace_name has a value which is a string
+	workspace_id has a value which is an int
 Report is a reference to a hash where the following keys are defined:
 	text_message has a value which is a string
 	warnings has a value which is a reference to a list where each element is a string
@@ -158,6 +159,7 @@ $info is a KBaseReport.ReportInfo
 CreateParams is a reference to a hash where the following keys are defined:
 	report has a value which is a KBaseReport.Report
 	workspace_name has a value which is a string
+	workspace_id has a value which is an int
 Report is a reference to a hash where the following keys are defined:
 	text_message has a value which is a string
 	warnings has a value which is a reference to a list where each element is a string
@@ -265,6 +267,7 @@ CreateExtendedReportParams is a reference to a hash where the following keys are
 	html_window_height has a value which is a float
 	summary_window_height has a value which is a float
 	workspace_name has a value which is a string
+	workspace_id has a value which is an int
 WorkspaceObject is a reference to a hash where the following keys are defined:
 	ref has a value which is a KBaseReport.ws_id
 	description has a value which is a string
@@ -298,6 +301,7 @@ CreateExtendedReportParams is a reference to a hash where the following keys are
 	html_window_height has a value which is a float
 	summary_window_height has a value which is a float
 	workspace_name has a value which is a string
+	workspace_id has a value which is an int
 WorkspaceObject is a reference to a hash where the following keys are defined:
 	ref has a value which is a KBaseReport.ws_id
 	description has a value which is a string
@@ -664,7 +668,7 @@ direct_html_link_index has a value which is an int
 
 =item Description
 
-Provide the report information.  The structure is:
+Provide the report information. Either workspace name or workspace id is required  The structure is:
     params = {
         report: {
             text_message: '',
@@ -675,6 +679,7 @@ Provide the report information.  The structure is:
             }]
         },
         workspace_name: 'ws'
+        workspace_id: id
     }
 
 
@@ -686,6 +691,7 @@ Provide the report information.  The structure is:
 a reference to a hash where the following keys are defined:
 report has a value which is a KBaseReport.Report
 workspace_name has a value which is a string
+workspace_id has a value which is an int
 
 </pre>
 
@@ -696,6 +702,7 @@ workspace_name has a value which is a string
 a reference to a hash where the following keys are defined:
 report has a value which is a KBaseReport.Report
 workspace_name has a value which is a string
+workspace_id has a value which is an int
 
 
 =end text
@@ -805,7 +812,9 @@ The following parameters indicate where the report object should be saved in the
 string report_object_name - name to use for the report object (job ID is used if left unspecified)
 html_window_height - height of the html window in the narrative output widget
 summary_window_height - height of summary window in the narrative output widget
+One of the following:
 string workspace_name - name of workspace where object should be saved
+int workspace_id - id of workspace where object should be saved
 
 
 =item Definition
@@ -825,6 +834,7 @@ report_object_name has a value which is a string
 html_window_height has a value which is a float
 summary_window_height has a value which is a float
 workspace_name has a value which is a string
+workspace_id has a value which is an int
 
 </pre>
 
@@ -844,6 +854,7 @@ report_object_name has a value which is a string
 html_window_height has a value which is a float
 summary_window_height has a value which is a float
 workspace_name has a value which is a string
+workspace_id has a value which is an int
 
 
 =end text

--- a/lib/KBaseReport/KBaseReportClient.py
+++ b/lib/KBaseReport/KBaseReportClient.py
@@ -37,9 +37,10 @@ class KBaseReport(object):
         """
         Create a KBaseReport with a brief summary of an App run.
         :param params: instance of type "CreateParams" (Provide the report
-           information.  The structure is: params = { report: { text_message:
-           '', warnings: ['w1'], objects_created: [ { ref: 'ws/objid',
-           description: '' }] }, workspace_name: 'ws' }) -> structure:
+           information. Either workspace name or workspace id is required 
+           The structure is: params = { report: { text_message: '', warnings:
+           ['w1'], objects_created: [ { ref: 'ws/objid', description: '' }]
+           }, workspace_name: 'ws' workspace_id: id }) -> structure:
            parameter "report" of type "Report" (A simple Report of a method
            run in KBase. It only provides for now a way to display a fixed
            width text output summary message, a list of warnings, and a list
@@ -66,7 +67,7 @@ class KBaseReport(object):
            String, parameter "name" of String, parameter "label" of String,
            parameter "URL" of String, parameter "direct_html" of String,
            parameter "direct_html_link_index" of Long, parameter
-           "workspace_name" of String
+           "workspace_name" of String, parameter "workspace_id" of Long
         :returns: instance of type "ReportInfo" (The reference to the saved
            KBaseReport.  The structure is: reportInfo = { ref:
            'ws/objid/ver', name: 'myreport.2262323452' }) -> structure:
@@ -105,24 +106,25 @@ class KBaseReport(object):
            for the report object (job ID is used if left unspecified)
            html_window_height - height of the html window in the narrative
            output widget summary_window_height - height of summary window in
-           the narrative output widget string workspace_name - name of
-           workspace where object should be saved) -> structure: parameter
-           "message" of String, parameter "objects_created" of list of type
-           "WorkspaceObject" (Represents a Workspace object with some brief
-           description text that can be associated with the object. @optional
-           description) -> structure: parameter "ref" of type "ws_id" (@id
-           ws), parameter "description" of String, parameter "warnings" of
-           list of String, parameter "html_links" of list of type "File" ->
-           structure: parameter "path" of String, parameter "shock_id" of
-           String, parameter "name" of String, parameter "description" of
-           String, parameter "direct_html" of String, parameter
-           "direct_html_link_index" of Long, parameter "file_links" of list
-           of type "File" -> structure: parameter "path" of String, parameter
-           "shock_id" of String, parameter "name" of String, parameter
-           "description" of String, parameter "report_object_name" of String,
-           parameter "html_window_height" of Double, parameter
-           "summary_window_height" of Double, parameter "workspace_name" of
-           String
+           the narrative output widget One of the following: string
+           workspace_name - name of workspace where object should be saved
+           int workspace_id - id of workspace where object should be saved)
+           -> structure: parameter "message" of String, parameter
+           "objects_created" of list of type "WorkspaceObject" (Represents a
+           Workspace object with some brief description text that can be
+           associated with the object. @optional description) -> structure:
+           parameter "ref" of type "ws_id" (@id ws), parameter "description"
+           of String, parameter "warnings" of list of String, parameter
+           "html_links" of list of type "File" -> structure: parameter "path"
+           of String, parameter "shock_id" of String, parameter "name" of
+           String, parameter "description" of String, parameter "direct_html"
+           of String, parameter "direct_html_link_index" of Long, parameter
+           "file_links" of list of type "File" -> structure: parameter "path"
+           of String, parameter "shock_id" of String, parameter "name" of
+           String, parameter "description" of String, parameter
+           "report_object_name" of String, parameter "html_window_height" of
+           Double, parameter "summary_window_height" of Double, parameter
+           "workspace_name" of String, parameter "workspace_id" of Long
         :returns: instance of type "ReportInfo" (The reference to the saved
            KBaseReport.  The structure is: reportInfo = { ref:
            'ws/objid/ver', name: 'myreport.2262323452' }) -> structure:

--- a/lib/src/us/kbase/kbasereport/CreateExtendedReportParams.java
+++ b/lib/src/us/kbase/kbasereport/CreateExtendedReportParams.java
@@ -31,7 +31,9 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * string report_object_name - name to use for the report object (job ID is used if left unspecified)
  * html_window_height - height of the html window in the narrative output widget
  * summary_window_height - height of summary window in the narrative output widget
+ * One of the following:
  * string workspace_name - name of workspace where object should be saved
+ * int workspace_id - id of workspace where object should be saved
  * </pre>
  * 
  */
@@ -48,7 +50,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
     "report_object_name",
     "html_window_height",
     "summary_window_height",
-    "workspace_name"
+    "workspace_name",
+    "workspace_id"
 })
 public class CreateExtendedReportParams {
 
@@ -74,6 +77,8 @@ public class CreateExtendedReportParams {
     private Double summaryWindowHeight;
     @JsonProperty("workspace_name")
     private java.lang.String workspaceName;
+    @JsonProperty("workspace_id")
+    private Long workspaceId;
     private Map<java.lang.String, Object> additionalProperties = new HashMap<java.lang.String, Object>();
 
     @JsonProperty("message")
@@ -241,6 +246,21 @@ public class CreateExtendedReportParams {
         return this;
     }
 
+    @JsonProperty("workspace_id")
+    public Long getWorkspaceId() {
+        return workspaceId;
+    }
+
+    @JsonProperty("workspace_id")
+    public void setWorkspaceId(Long workspaceId) {
+        this.workspaceId = workspaceId;
+    }
+
+    public CreateExtendedReportParams withWorkspaceId(Long workspaceId) {
+        this.workspaceId = workspaceId;
+        return this;
+    }
+
     @JsonAnyGetter
     public Map<java.lang.String, Object> getAdditionalProperties() {
         return this.additionalProperties;
@@ -253,7 +273,7 @@ public class CreateExtendedReportParams {
 
     @Override
     public java.lang.String toString() {
-        return ((((((((((((((((((((((((("CreateExtendedReportParams"+" [message=")+ message)+", objectsCreated=")+ objectsCreated)+", warnings=")+ warnings)+", htmlLinks=")+ htmlLinks)+", directHtml=")+ directHtml)+", directHtmlLinkIndex=")+ directHtmlLinkIndex)+", fileLinks=")+ fileLinks)+", reportObjectName=")+ reportObjectName)+", htmlWindowHeight=")+ htmlWindowHeight)+", summaryWindowHeight=")+ summaryWindowHeight)+", workspaceName=")+ workspaceName)+", additionalProperties=")+ additionalProperties)+"]");
+        return ((((((((((((((((((((((((((("CreateExtendedReportParams"+" [message=")+ message)+", objectsCreated=")+ objectsCreated)+", warnings=")+ warnings)+", htmlLinks=")+ htmlLinks)+", directHtml=")+ directHtml)+", directHtmlLinkIndex=")+ directHtmlLinkIndex)+", fileLinks=")+ fileLinks)+", reportObjectName=")+ reportObjectName)+", htmlWindowHeight=")+ htmlWindowHeight)+", summaryWindowHeight=")+ summaryWindowHeight)+", workspaceName=")+ workspaceName)+", workspaceId=")+ workspaceId)+", additionalProperties=")+ additionalProperties)+"]");
     }
 
 }

--- a/lib/src/us/kbase/kbasereport/CreateParams.java
+++ b/lib/src/us/kbase/kbasereport/CreateParams.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 /**
  * <p>Original spec-file type: CreateParams</p>
  * <pre>
- * Provide the report information.  The structure is:
+ * Provide the report information. Either workspace name or workspace id is required  The structure is:
  *     params = {
  *         report: {
  *             text_message: '',
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  *             }]
  *         },
  *         workspace_name: 'ws'
+ *         workspace_id: id
  *     }
  * </pre>
  * 
@@ -33,7 +34,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 @Generated("com.googlecode.jsonschema2pojo")
 @JsonPropertyOrder({
     "report",
-    "workspace_name"
+    "workspace_name",
+    "workspace_id"
 })
 public class CreateParams {
 
@@ -54,6 +56,8 @@ public class CreateParams {
     private Report report;
     @JsonProperty("workspace_name")
     private String workspaceName;
+    @JsonProperty("workspace_id")
+    private Long workspaceId;
     private Map<String, Object> additionalProperties = new HashMap<String, Object>();
 
     /**
@@ -112,6 +116,21 @@ public class CreateParams {
         return this;
     }
 
+    @JsonProperty("workspace_id")
+    public Long getWorkspaceId() {
+        return workspaceId;
+    }
+
+    @JsonProperty("workspace_id")
+    public void setWorkspaceId(Long workspaceId) {
+        this.workspaceId = workspaceId;
+    }
+
+    public CreateParams withWorkspaceId(Long workspaceId) {
+        this.workspaceId = workspaceId;
+        return this;
+    }
+
     @JsonAnyGetter
     public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
@@ -124,7 +143,7 @@ public class CreateParams {
 
     @Override
     public String toString() {
-        return ((((((("CreateParams"+" [report=")+ report)+", workspaceName=")+ workspaceName)+", additionalProperties=")+ additionalProperties)+"]");
+        return ((((((((("CreateParams"+" [report=")+ report)+", workspaceName=")+ workspaceName)+", workspaceId=")+ workspaceId)+", additionalProperties=")+ additionalProperties)+"]");
     }
 
 }

--- a/test/KBaseReport_server_test.pl
+++ b/test/KBaseReport_server_test.pl
@@ -14,6 +14,7 @@ my $config_file = $ENV{'KB_DEPLOYMENT_CONFIG'};
 my $config = new Config::Simple($config_file)->get_block('KBaseReport');
 my $ws_url = $config->{"workspace-url"};
 my $ws_name = undef;
+my $ws_info = undef;
 my $ws_client = Workspace::WorkspaceClient->new($ws_url,token => $token);
 my $auth_token = Bio::KBase::AuthToken->new(token => $token, ignore_authrc => 1, auth_svc=>$config->{'auth-service-url'});
 print("ws url:".$config->{'workspace-url'} . "\n");
@@ -81,36 +82,36 @@ my $mikes_report_param = {
     report => $mikes_report_hash
 };
 
-sub get_ws_name {
+sub get_ws {
     if (!defined($ws_name)) {
         my $suffix = int(time * 1000);
         $ws_name = 'test_KBaseReport_' . $suffix;
         $ws_name = 'test_KBaseReport_' . $suffix;
-        $ws_client->create_workspace({workspace => $ws_name});
+        $ws_info = $ws_client->create_workspace({workspace => $ws_name});
     }
-    return $ws_name;
+    return [$ws_name, $ws_info->[0]];
 }
 
 lives_ok {
-   $createReport->{workspace_name} = get_ws_name();
+   $createReport->{workspace_name} = get_ws()->[0];
    my $ret =$impl->create_extended_report($createReport);
    print Dumper($ret);
 };
 
 lives_ok {
-   $mikes_report_param->{workspace_name} = get_ws_name();
+   $mikes_report_param->{workspace_name} = get_ws()->[0];
    my $ret =$impl->create($mikes_report_param);
    print Dumper($ret);
 };
 
 lives_ok {
-   $createReport->{workspace_id} = 7601;
+   $createReport->{workspace_id} = get_ws()->[1];
    my $ret =$impl->create_extended_report($createReport);
    print Dumper($ret);
 };
 
 lives_ok {
-   $mikes_report_param->{workspace_id} = 7601;
+   $mikes_report_param->{workspace_id} = get_ws()->[1];
    my $ret =$impl->create($mikes_report_param);
    print Dumper($ret);
 };

--- a/test/KBaseReport_server_test.pl
+++ b/test/KBaseReport_server_test.pl
@@ -1,6 +1,7 @@
 use strict;
 use Data::Dumper;
 use Test::More;
+use Test::Exception;
 use Config::Simple;
 use Time::HiRes qw(time);
 use Bio::KBase::AuthToken;
@@ -53,8 +54,8 @@ my $htmlfile2 = {
 };
 
 my $list_ob = {
-    ref => '7995/29/72',
-    description => 'sample_reads_object'
+    ref => '7601/48/57',
+    description => 'sample_fba_model'
 
 };
 
@@ -65,7 +66,7 @@ my $createReport = {
     file_links => [$file1, $file2],
     html_links => [$htmlfile1,$htmlfile2],
     direct_html => $html_string,
-    #objects_created => [$list_ob],
+    objects_created => [$list_ob],
     message => "testReporterObject"
 };
 
@@ -90,70 +91,37 @@ sub get_ws_name {
     return $ws_name;
 }
 
-eval {
-   my $ws_name = get_ws_name();
-   $createReport->{workspace_name} = $ws_name;
+lives_ok {
+   $createReport->{workspace_name} = get_ws_name();
    my $ret =$impl->create_extended_report($createReport);
    print Dumper($ret);
-   #my $ret =$impl->create($mikes_report_param);
-
-
 };
 
-
-
-=head
-sub get_ws_name {
-    if (!defined($ws_name)) {
-        my $suffix = int(time * 1000);
-        $ws_name = 'test_KBaseReport_' . $suffix;
-        $ws_name = 'test_KBaseReport_' . $suffix;
-        $ws_client->create_workspace({workspace => $ws_name});
-    }
-    return $ws_name;
-}
-eval {
-    my $ret;
-    eval {
-        $ret = $impl->create({
-                report => {
-                    objects_created => [],
-                    text_message => "Some report"
-                },
-                workspace_name => self->get_ws_name()
-        });
-    };
-    ok(!$@,"create command successful");
-    eval {
-        $ret = $impl->create_report({
-                report => {
-                    objects_created => [],
-                    text_message => "Some report"
-                },
-                workspace_name => self->get_ws_name()
-        });
-    };
-    ok(!$@,"create_report command successful");
-    done_testing(2);
+lives_ok {
+   $mikes_report_param->{workspace_name} = get_ws_name();
+   my $ret =$impl->create($mikes_report_param);
+   print Dumper($ret);
 };
-=cut
-my $err = undef;
-if ($@) {
-    $err = $@;
-}
+
+lives_ok {
+   $createReport->{workspace_id} = 7601;
+   my $ret =$impl->create_extended_report($createReport);
+   print Dumper($ret);
+};
+
+lives_ok {
+   $mikes_report_param->{workspace_id} = 7601;
+   my $ret =$impl->create($mikes_report_param);
+   print Dumper($ret);
+};
+done_testing(4);
+
 eval {
     if (defined($ws_name)) {
         $ws_client->delete_workspace({workspace => $ws_name});
         print("Test workspace was deleted\n");
     }
 };
-if (defined($err)) {
-    if(ref($err) eq "Bio::KBase::Exceptions::KBaseException") {
-        die("Error while running tests: " . $err->trace->as_string);
-    } else {
-        die $err;
-    }
-}
 
 {
     package LocalCallContext;

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,0 +1,14 @@
+This directory should contain any UI elements needed for your module. These come in two sections.
+
+**1. Narrative Method Specs**  
+The narrative/methods/count_contigs_in_set directory
+contains the spec.json and display.yaml files that are needed for the KBase Narrative to use 
+methods in your module as a clickable KBase method. See **[INSERT LOCATION HERE]** for details
+on how to write a method spec.
+
+**2. UI visualization modules**  
+To support a KBase method, UI modules are often necessary. There are, in general, three classes
+of these - one to display inputs to a method, one to display outputs from a method, and one to
+visualize data (the output widgets and data visualizers are often the same). Though there are
+functional defaults for these, it may be necessary to build custom widgets depending on your 
+methods. These should go under the widgets/ directory.  


### PR DESCRIPTION
The primary change here is to allow create & create_extended_report to accept either workspace_name or workspace_id with workspace_id taking precedence if both are present. While I was in the neighborhood I made a number of other refactoring changes such as updating the tests, adding a travis file and adding a ui directory so that kb-sdk recognizes this as a module