### PR TITLE
Updating kbase report templates submodule

### DIFF
--- a/deploy.cfg
+++ b/deploy.cfg
@@ -11,7 +11,6 @@ auth-service-url-allow-insecure = {{ auth_service_url_allow_insecure }}
 scratch = /kb/module/work/tmp
 
 [TemplateToolkitPython]
-TRIM = 1
 ABSOLUTE = 1
 RELATIVE = 1
 INCLUDE_PATH = /kb/module/kbase_report_templates/:/kb/module/kbase_report_templates/views/

--- a/test/KBaseReport_server_test.py
+++ b/test/KBaseReport_server_test.py
@@ -213,7 +213,10 @@ class KBaseReportTest(unittest.TestCase):
                     },
                 })
                 data = self.check_created_report(result)
-                self.assertMultiLineEqual(data['direct_html'], ref_text['abs_path'])
+                self.assertMultiLineEqual(
+                    data['direct_html'].rstrip(), 
+                    ref_text['abs_path'].rstrip()
+                )
 
     def test_create_param_errors(self):
         """

--- a/test/TemplateUtil_test.py
+++ b/test/TemplateUtil_test.py
@@ -254,7 +254,7 @@ class TestTemplateUtils(unittest.TestCase):
 
         with open(new_file, 'r') as f:
             rendered_text = f.read()
-        self.assertMultiLineEqual(rendered_text.rstrip(), ref_text)
+        self.assertMultiLineEqual(rendered_text.rstrip(), ref_text.rstrip())
 
     def test_class_init(self):
         """ TemplateUtil: class initialisation """

--- a/test/data/tmpl_output_None.txt
+++ b/test/data/tmpl_output_None.txt
@@ -1,13 +1,15 @@
 <!doctype html>
 <html lang="en">
 <head>
-<meta charset="utf-8" />
+  <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+
   <title></title>
 </head>
 <body>
 <div class="container-fluid kb-html-report">
 <!-- /kb/module/kbase_report_templates/views/test/test_template.tt -->
+
 <h1></h1>
 <div>This is a test.</div>
 <div>The value is </div>

--- a/test/data/tmpl_output_content.txt
+++ b/test/data/tmpl_output_content.txt
@@ -1,13 +1,15 @@
 <!doctype html>
 <html lang="en">
 <head>
-<meta charset="utf-8" />
+  <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+
   <title></title>
 </head>
 <body>
 <div class="container-fluid kb-html-report">
 <!-- /kb/module/kbase_report_templates/views/test/test_template.tt -->
+
 <h1></h1>
 <div>This is a test.</div>
 <div>The value is ['this', 'that', 'the other']</div>

--- a/test/data/tmpl_output_title.txt
+++ b/test/data/tmpl_output_title.txt
@@ -1,13 +1,15 @@
 <!doctype html>
 <html lang="en">
 <head>
-<meta charset="utf-8" />
+  <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+
   <title>My First Template</title>
 </head>
 <body>
 <div class="container-fluid kb-html-report">
 <!-- /kb/module/kbase_report_templates/views/test/test_template.tt -->
+
 <h1>My First Template</h1>
 <div>This is a test.</div>
 <div>The value is </div>


### PR DESCRIPTION
Removed 'TRIM' config setting (which deals with whitespace removal) and updated tests accordingly.

Updated kbase_report_templates submodule.